### PR TITLE
resolve #6 漫画オブジェクトのメンバに作者オブジェクトを追加

### DIFF
--- a/src/oop/basic/Author.ts
+++ b/src/oop/basic/Author.ts
@@ -1,0 +1,54 @@
+/**
+ * 書籍の作者を表すクラス
+ */
+import Isbn from "./Isbn";
+
+export default class Author {
+  /**
+   * 名
+   */
+  private readonly _givenName: string;
+
+  /**
+   * 姓
+   */
+  private readonly _familyName: string;
+
+  /**
+   * @param {string} givenName
+   * @param {string} familyName
+   */
+  constructor(givenName: string, familyName: string) {
+    this._givenName = givenName;
+    this._familyName = familyName;
+  }
+
+  /**
+   * @returns {string}
+   */
+  get givenName(): string {
+    return this._givenName;
+  }
+
+  /**
+   * @returns {string}
+   */
+  get familyName(): string {
+    return this._familyName;
+  }
+
+  /**
+   * 作者のフルネームを取得する
+   *
+   * @param {Isbn} isbn
+   * @returns {string}
+   */
+  fullName(isbn?: Isbn): string {
+    // 書籍の言語が日本語の場合だけ姓、名の順番で返す
+    if (isbn != null && isbn.extractLanguage() === "ja") {
+      return `${this.familyName} ${this.givenName}`;
+    }
+
+    return `${this.givenName} ${this.familyName}`;
+  }
+}

--- a/src/oop/basic/Comic.ts
+++ b/src/oop/basic/Comic.ts
@@ -2,6 +2,7 @@ import Book from "./Book";
 import Isbn from "./Isbn";
 import Price from "./Price";
 import Title from "./Title";
+import Author from "./Author";
 
 /**
  * 漫画クラス
@@ -23,14 +24,21 @@ export default class Comic implements Book {
   private readonly _price: Price;
 
   /**
+   * 作者
+   */
+  private readonly _author: Author;
+
+  /**
    * @param {Isbn} isbn
    * @param {Title} title
    * @param {Price} price
+   * @param {Author} author
    */
-  constructor(isbn: Isbn, title: Title, price: Price) {
+  constructor(isbn: Isbn, title: Title, price: Price, author: Author) {
     this._isbn = isbn;
     this._title = title;
     this._price = price;
+    this._author = author;
   }
 
   /**
@@ -52,5 +60,21 @@ export default class Comic implements Book {
    */
   get price(): Price {
     return this._price;
+  }
+
+  /**
+   * @returns {Author}
+   */
+  get author(): Author {
+    return this._author;
+  }
+
+  /**
+   * 作者のフルネームを取得する
+   *
+   * @returns {string}
+   */
+  extractAuthorFullName(): string {
+    return this.author.fullName(this.isbn);
   }
 }

--- a/test/unit/oop/basic/author.spec.ts
+++ b/test/unit/oop/basic/author.spec.ts
@@ -1,0 +1,22 @@
+import Author from "../../../../src/oop/basic/Author";
+import Isbn from "../../../../src/oop/basic/Isbn";
+
+/**
+ * 作者クラスのテスト
+ */
+describe("Author", () => {
+  /**
+   * 意図したフルネームを取得出来る事を確認する
+   */
+  it("should be able to get the intended FullName", () => {
+    const enAuthor = new Author("Taylor", "Swift");
+
+    expect(enAuthor.fullName()).toBe("Taylor Swift");
+
+    const jaAuthor = new Author("アキコ", "東村");
+
+    const isbnJapan = new Isbn("978-4-09-825202-2");
+
+    expect(jaAuthor.fullName(isbnJapan)).toBe("東村 アキコ");
+  });
+});

--- a/test/unit/oop/basic/comic.spec.ts
+++ b/test/unit/oop/basic/comic.spec.ts
@@ -2,6 +2,7 @@ import Comic from "../../../../src/oop/basic/Comic";
 import Isbn from "../../../../src/oop/basic/Isbn";
 import Title from "../../../../src/oop/basic/Title";
 import Price from "../../../../src/oop/basic/Price";
+import Author from "../../../../src/oop/basic/Author";
 
 /**
  * 漫画クラスのテスト
@@ -14,11 +15,13 @@ describe("Comic", () => {
     const isbn = new Isbn("978-4-06-319239-1");
     const title = new Title("ちはやふる", "第1巻");
     const price = new Price(463, 108);
+    const author = new Author("由紀", "末次");
 
-    const comic = new Comic(isbn, title, price);
+    const comic = new Comic(isbn, title, price, author);
 
     expect(comic.isbn.extractLanguage()).toBe("ja");
     expect(comic.title.fullTitle()).toBe("ちはやふる 第1巻");
     expect(comic.price.calculateIncludingTaxPrice()).toBe(500);
+    expect(comic.extractAuthorFullName()).toBe("末次 由紀");
   });
 });


### PR DESCRIPTION
# issue URL
https://github.com/keitakn/design-pattern-tips/issues/6

# やった事
- 漫画オブジェクトのメンバに作者オブジェクトを追加

Bookインターフェースには作者オブジェクトを追加していない。（雑誌等の作者が載っていない書籍を考慮したつもり）